### PR TITLE
DAO-399 generate artifacts always if app has contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/hardhat-aragon",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Hardhat plugin for developing Aragon apps.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/tasks/publish.ts
+++ b/src/tasks/publish.ts
@@ -3,7 +3,7 @@ import { AragonPluginError } from '../errors'
 import { HardhatRuntimeEnvironment, HttpNetworkConfig } from 'hardhat/types'
 
 import { DEFAULT_IPFS_API_ENDPOINT, EXPLORER_CHAIN_URLS } from '../constants'
-import { PublishTaskArguments, RepoContent } from '../types'
+import { PublishTaskArguments } from '../types'
 
 import { log } from '../utils/logger'
 import * as apm from '../utils/apm'

--- a/src/tasks/publish.ts
+++ b/src/tasks/publish.ts
@@ -135,21 +135,13 @@ export async function publishTask(
   }
 
   if (!args.onlyContent) {
-    let content: RepoContent
-    if (prevVersion && bump !== 'major') {
-      log(`Resolving Aragon artifacts from Aragon Package Manager`)
-      content = await apm.resolveRepoContentUri(prevVersion.contentUri, {
-        ipfsGateway: hre.config.ipfs.gateway,
-      })
-    } else {
-      log(`Generating Aragon app artifacts`)
-      content = await generateArtifacts(
-        arapp,
-        finalAppEnsName,
-        appContractName,
-        hre
-      )
-    }
+    log(`Generating Aragon app artifacts`)
+    const content = await generateArtifacts(
+      arapp,
+      finalAppEnsName,
+      appContractName,
+      hre
+    )
 
     writeArtifacts(appBuildOutputPath, content)
 

--- a/src/utils/artifact/generateArtifacts.ts
+++ b/src/utils/artifact/generateArtifacts.ts
@@ -1,5 +1,6 @@
 import { TASK_FLATTEN_GET_FLATTENED_SOURCE } from 'hardhat/builtin-tasks/task-names'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { TASK_COMPILE_CONTRACT } from '../../task-names'
 
 import { MANIFEST_NAME } from '../../constants'
 import { AragonAppJson, AragonManifest, RepoContent } from '../../types'
@@ -22,6 +23,8 @@ export async function generateArtifacts(
   hre: HardhatRuntimeEnvironment
 ): Promise<RepoContent> {
   const { roles: appRoles, dependencies: appDependencies = [] } = arapp
+
+  await hre.run(TASK_COMPILE_CONTRACT)
 
   // Get ABI from generated artifacts in compilation
   const { abi } = await hre.artifacts.readArtifact(appContractName)


### PR DESCRIPTION
# 🦅 Pull Request Description

Currently, the hardhat-aragon publish script only generates contract artifacts from the github source if a new contract is deployed. If the previous contract version was used, the script will pull the contract artifacts from IPFS.  This presents a problem if the previous deployment had a faulty upload to IPFS, and this is often the case requiring a redeployment.

## Rational

Solution is to go back to what the buidler-aragon publish script used to do... generate the contract artifacts from github source even if previous contract version was used... same case as when a contract address was provided to the publish script.

## 🚨 Test instructions

run the hardhat publish script to deploy a previously deployed app with minor or patch version.

